### PR TITLE
pg 修改或者周数的函数实现

### DIFF
--- a/src/main/resources/postgresql_function.json
+++ b/src/main/resources/postgresql_function.json
@@ -928,7 +928,7 @@
     },
     {
       "name": "toWeek",
-      "function": "date_part('week', timestamp #1)",
+      "function": "to_char(#1,'WW')",
       "describe": "周天",
       "paramSizeType": "fixed",
       "paramMinSize": 1,


### PR DESCRIPTION
pg 获取周的函数使用to_char实现，原来的date_part，参数必须是字符串，切不能嵌套to_char函数，所以使用to_char函数实现

<!--Thanks very much for contributing to Data Integration.-->


## Purpose of the pull request

<!--(For example: This pull request adds checkstyle plugin).-->

## Brief change log

<!--*(for example:)*
  - *Add maven-checkstyle-plugin to root pom.xml*
-->
## Verify this pull request

<!--*(Please pick either of the following options)*-->

This pull request is code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

<!--*(example:)*
  - *Added dataintegration-dao tests for end-to-end.*
  - *Added CronUtilsTest to verify the change.*
  - *Manually verified the change by testing locally.* -->
