### PR TITLE
clickhouse 加权平均isNaN对于sum(a*b)这种参数使用有限制，所以考虑使用其他方式来处理，clickhosue在分子为0…

### DIFF
--- a/src/main/resources/clickhouse_function.json
+++ b/src/main/resources/clickhouse_function.json
@@ -967,7 +967,7 @@
     },
     {
       "name": "weighted_mean",
-      "function": "IF (isNaN(SUM(#1*#2)/SUM(#2)) == 1 or  isInfinite(SUM(#1*#2)/SUM(#2)) ==1 ,NULL , SUM(#1*#2)/SUM(#2))",
+      "function": "IF (SUM(#1) = 0  or SUM(#1 * #2) = 0 , null, SUM(#1 * #2)/ SUM(#2))",
       "describe": "加权平均",
       "paramSizeType": "fixed",
       "paramMinSize": 2,


### PR DESCRIPTION
clickhouse 加权平均isNaN对于sum(a*b)这种参数使用有限制，所以考虑使用其他方式来处理，clickhosue在分子为0时返回infinity，在分母为0时返回NaN，所以判断当分母分子为0时不进行加权计算。返回null。